### PR TITLE
Update Dockerfile with caddy-dns SHA

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -508,12 +508,10 @@ jobs:
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOME: ${{ github.workspace }}
         run: |
-          # Create Docker config directory in the workspace
-          mkdir -p ${{ github.workspace }}/.docker
-          # Set Docker config path to workspace directory
-          echo "DOCKER_CONFIG=${{ github.workspace }}/.docker" >> $GITHUB_ENV
-          # Login to GitHub Container Registry
+          mkdir -p $HOME/.docker
+          echo '{"auths":{"ghcr.io":{}}}' > $HOME/.docker/config.json
           echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
 
       - name: Push images

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -505,11 +505,16 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: success()
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create Docker config directory in the workspace
+          mkdir -p ${{ github.workspace }}/.docker
+          # Set Docker config path to workspace directory
+          echo "DOCKER_CONFIG=${{ github.workspace }}/.docker" >> $GITHUB_ENV
+          # Login to GitHub Container Registry
+          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
 
       - name: Push images
         if: success()

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -503,7 +503,7 @@ jobs:
             gh pr comment ${{ github.event.pull_request.number }} --body "✅ No vulnerabilities found in \`${{ steps.version.outputs.image_name }}\` image"
           fi
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to GitHub Container Registry and push images
         if: success()
         env:
           GITHUB_USER: ${{ github.actor }}
@@ -517,9 +517,6 @@ jobs:
           # Use --password-stdin to avoid credential leakage in logs
           echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
 
-      - name: Push images
-        if: success()
-        run: |
           # Push the images
           docker push ghcr.io/blockjoy/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.image_tag }}
           docker push ghcr.io/blockjoy/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.version_tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -447,20 +447,20 @@ jobs:
           
       - name: Run Trivy vulnerability scanner
         id: scan
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'image'
-          image-ref: 'localhost/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.image_tag }}'
-          format: 'table'
-          severity: 'CRITICAL,HIGH'
-          timeout: '10m'
-          exit-code: '0'
-
-      - name: Generate human-readable report
         if: always()
         run: |
           set -x
-          trivy image --severity CRITICAL,HIGH --format table localhost/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.image_tag }} > trivy-image-results.txt
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v $(pwd):/workspace \
+            aquasec/trivy:latest \
+            image \
+            --severity CRITICAL,HIGH \
+            --format table \
+            --timeout 10m \
+            localhost/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.image_tag }} > trivy-image-results.txt
+          
+          cat trivy-image-results.txt
 
       - name: Comment on PR
         if: always()

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -458,7 +458,7 @@ jobs:
             --severity CRITICAL,HIGH \
             --format table \
             --timeout 10m \
-            localhost/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.image_tag }} > trivy-image-results.txt
+            ghcr.io/blockjoy/${IMAGE_NAME}:${IMAGE_TAG} > trivy-image-results.txt
           
           cat trivy-image-results.txt
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -521,12 +521,12 @@ jobs:
         if: success()
         run: |
           # Push the images
-          docker push ghcr.io/blockjoy/${IMAGE_NAME}:${IMAGE_TAG}
-          docker push ghcr.io/blockjoy/${IMAGE_NAME}:${VERSION_TAG}
+          docker push ghcr.io/blockjoy/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.image_tag }}
+          docker push ghcr.io/blockjoy/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.version_tag }}
           
           echo "Successfully built and pushed images:"
-          echo "  - ghcr.io/blockjoy/${IMAGE_NAME}:${IMAGE_TAG}"
-          echo "  - ghcr.io/blockjoy/${IMAGE_NAME}:${VERSION_TAG}"
+          echo "  - ghcr.io/blockjoy/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.image_tag}}"
+          echo "  - ghcr.io/blockjoy/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.version_tag}}"
 
   build-clients:
     needs: [detect-changes, scan-dockerfiles]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -508,10 +508,13 @@ jobs:
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOME: ${{ github.workspace }}
         run: |
-          mkdir -p $HOME/.docker
-          echo '{"auths":{"ghcr.io":{}}}' > $HOME/.docker/config.json
+          # Configure Docker to not store credentials
+          mkdir -p $GITHUB_WORKSPACE/.docker
+          echo '{"credsStore":"","auths":{"ghcr.io":{}}}' > $GITHUB_WORKSPACE/.docker/config.json
+          export DOCKER_CONFIG=$GITHUB_WORKSPACE/.docker
+          
+          # Use --password-stdin to avoid credential leakage in logs
           echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
 
       - name: Push images

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -505,17 +505,11 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: success()
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Configure Docker to not store credentials
-          mkdir -p $GITHUB_WORKSPACE/.docker
-          echo '{"credsStore":"","auths":{"ghcr.io":{}}}' > $GITHUB_WORKSPACE/.docker/config.json
-          export DOCKER_CONFIG=$GITHUB_WORKSPACE/.docker
-          
-          # Use --password-stdin to avoid credential leakage in logs
-          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images
         if: success()

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -458,7 +458,7 @@ jobs:
             --severity CRITICAL,HIGH \
             --format table \
             --timeout 10m \
-            ghcr.io/blockjoy/${IMAGE_NAME}:${IMAGE_TAG} > trivy-image-results.txt
+            ghcr.io/blockjoy/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.image_tag }} > trivy-image-results.txt
           
           cat trivy-image-results.txt
 

--- a/base-images/debian-bookworm/Dockerfile
+++ b/base-images/debian-bookworm/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.23.1 AS go-builder
 
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest && \
     cd / && \
-    xcaddy build --with github.com/caddy-dns/cloudflare --with github.com/blockjoy/request-decompressor
+    xcaddy build --with github.com/caddy-dns/cloudflare@1fb64108d4debf196b19d7398e763cb78c8a0f41 --with github.com/blockjoy/request-decompressor
 
 FROM debian:bookworm-slim@sha256:f70dc8d6a8b6a06824c92471a1a258030836b26b043881358b967bf73de7c5ab
 


### PR DESCRIPTION
The latest SHA for the caddy-dns Cloudflare plugin fails to build, pinning the second to last SHA fixes the issue